### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",


### PR DESCRIPTION
#### What's this PR do?
Bumps the version up one minor release so that we can push MS Office Online support and GitHub improvements.

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
