### PR TITLE
Add support for configurable attachment deduping

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -79,12 +79,21 @@ function orgsFromCookies() {
 // Posts a new suggestion to the Range servers on behalf of the user. Based on
 // the suggestion object it will be deduped.
 function recordInteraction(interaction, params) {
-  return post(`/v1/activity`, interaction, params);
+  return post('/v1/activity', interaction, params);
 }
 
+// Retrieves that last 100 attachments associated with this user
 function recentActivity(params) {
   return get(
-    `/v1/activity?collation=ATTACHMENT&attachment_visibility=NEW&include_dismissed=true&include_refs=true&limit=100`,
+    '/v1/activity?collation=ATTACHMENT&attachment_visibility=NEW&include_dismissed=true&include_refs=true&limit=100',
+    params
+  );
+}
+
+// Retrieves the last 100 attachments associated with this user for a given provider
+function listActivity(provider, params) {
+  return get(
+    `/v1/activity?include_attachment_providers=${provider}&collation=ATTACHMENT&attachment_visibility=NEW&include_dismissed=true&include_refs=true&limit=100`,
     params
   );
 }

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -189,19 +189,19 @@ async function attemptRecordInteraction(tab, session, force) {
 // new ones.
 async function mergeAttachment(session, attachment) {
   const dedupe = getProviderDedupe(attachment.provider);
-  if (dedupe == DEDUPE_BEHAVIOR.REPLACE) return attachment;
+  if (dedupe == MERGE_BEHAVIOR.REPLACE) return attachment;
 
   const activity = await listActivity(attachment.provider, authorize(session));
   for (const a of activity.attachments) {
     if (a.source_id != attachment.source_id) continue;
 
     switch (dedupe) {
-      case DEDUPE_BEHAVIOR.KEEP_NEW:
+      case MERGE_BEHAVIOR.MERGE_NEW:
         return {
           ...a,
           ...attachment,
         };
-      case DEDUPE_BEHAVIOR.KEEP_OLD:
+      case MERGE_BEHAVIOR.MERGE_EXISTING:
       default:
         return {
           ...attachment,

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -203,6 +203,7 @@ async function mergeAttachment(session, attachment) {
       if (ATTACHMENT_CORE.includes(f)) continue;
       delete attachment[f];
     }
+    break;
   }
 
   return attachment;

--- a/ext/background/const.js
+++ b/ext/background/const.js
@@ -7,11 +7,9 @@ const GUID_REGEX =
 
 const MERGE_BEHAVIOR = {
   // Keep all existing fields, fill remaining fields with new values
-  MERGE_EXISTING: 'MERGE_EXISTING',
-  // Keep all new fields, fill remaining fields with existing values
-  MERGE_NEW: 'MERGE_NEW',
-  // Completely replace the object without checking the old copy
-  REPLACE: 'REPLACE',
+  KEEP_EXISTING: 'KEEP_EXISTING',
+  // Replace existing fields with new attachment fields
+  REPLACE_EXISTING: 'REPLACE_EXISTING',
 };
 
 var INTEGRATION_STATUSES = {

--- a/ext/background/const.js
+++ b/ext/background/const.js
@@ -5,11 +5,11 @@ const BLOCK_LIST = { title: [/^chrome:\/\//, /^Range/] };
 const GUID_REGEX =
   '({){0,1}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(}){0,1}';
 
-const DEDUPE_BEHAVIOR = {
+const MERGE_BEHAVIOR = {
   // Keep all existing fields, fill remaining fields with new values
-  KEEP_OLD: 'KEEP_OLD',
+  MERGE_EXISTING: 'MERGE_EXISTING',
   // Keep all new fields, fill remaining fields with existing values
-  KEEP_NEW: 'KEEP_NEW',
+  MERGE_NEW: 'MERGE_NEW',
   // Completely replace the object without checking the old copy
   REPLACE: 'REPLACE',
 };

--- a/ext/background/const.js
+++ b/ext/background/const.js
@@ -5,6 +5,15 @@ const BLOCK_LIST = { title: [/^chrome:\/\//, /^Range/] };
 const GUID_REGEX =
   '({){0,1}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(}){0,1}';
 
+const DEDUPE_BEHAVIOR = {
+  // Keep all existing fields, fill remaining fields with new values
+  KEEP_OLD: 'KEEP_OLD',
+  // Keep all new fields, fill remaining fields with existing values
+  KEEP_NEW: 'KEEP_NEW',
+  // Completely replace the object without checking the old copy
+  REPLACE: 'REPLACE',
+};
+
 var INTEGRATION_STATUSES = {
   ENABLED: 'ENABLED',
   DISABLED: 'DISABLED',

--- a/ext/background/filter/filter.js
+++ b/ext/background/filter/filter.js
@@ -42,6 +42,14 @@ function registerFilter(filter) {
   chrome.storage.local.set({ filters: toStore });
 }
 
+function getProviderDedupe(provider) {
+  const f = _filters.filter((f) => f.provider == provider);
+  if (f && f.length > 0 && f[0].dedupe) {
+    return DEDUPE_BEHAVIOR[f[0].dedupe] || DEDUPE_BEHAVIOR.KEEP_OLD;
+  }
+  return DEDUPE_BEHAVIOR.KEEP_OLD;
+}
+
 async function tabHasFilter(tab) {
   const _enabledFilters = await enabledFilters();
   const provider = await providerInfo(new URL(tab.url), tab.title, true);

--- a/ext/background/filter/filter.js
+++ b/ext/background/filter/filter.js
@@ -45,9 +45,9 @@ function registerFilter(filter) {
 function getProviderDedupe(provider) {
   const f = _filters.filter((f) => f.provider == provider);
   if (f && f.length > 0 && f[0].dedupe) {
-    return DEDUPE_BEHAVIOR[f[0].dedupe] || DEDUPE_BEHAVIOR.KEEP_OLD;
+    return MERGE_BEHAVIOR[f[0].dedupe] || MERGE_BEHAVIOR.MERGE_EXISTING;
   }
-  return DEDUPE_BEHAVIOR.KEEP_OLD;
+  return MERGE_BEHAVIOR.MERGE_EXISTING;
 }
 
 async function tabHasFilter(tab) {

--- a/ext/background/filter/filter.js
+++ b/ext/background/filter/filter.js
@@ -45,9 +45,9 @@ function registerFilter(filter) {
 function getProviderDedupe(provider) {
   const f = _filters.filter((f) => f.provider == provider);
   if (f && f.length > 0 && f[0].dedupe) {
-    return MERGE_BEHAVIOR[f[0].dedupe] || MERGE_BEHAVIOR.MERGE_EXISTING;
+    return MERGE_BEHAVIOR[f[0].dedupe] || MERGE_BEHAVIOR.KEEP_EXISTING;
   }
-  return MERGE_BEHAVIOR.MERGE_EXISTING;
+  return MERGE_BEHAVIOR.KEEP_EXISTING;
 }
 
 async function tabHasFilter(tab) {


### PR DESCRIPTION
#### What's this PR do?
Creates deduping functionality that can be configured on a per-provider basis. There are 2 modes:

1. `KEEP_EXISTING`: Keep all existing fields, fill remaining fields with new values. **Note: This is the default**
2. `REPLACE_EXISTING`: Keep all new fields, fill remaining fields with existing values.

#### Where should the reviewer start?
Commit by commit, but it's not too big.

#### Any background context you want to provide?
We've been trying to figure out the most ergonomic approach to updating Range attachments without clobbering them with updates from webpages that aren't properly formed. For now, we've settled on the backend trusting its clients to send the correct information. This puts the onus on the extension to be smart about its updates. This also ensures that people who might be adding attachments through Zapier always know exactly what will happen when they add or update attachments.

This behavior and approach may be tweaked in the future.

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
