### PR TITLE
Fix premature return causing toggles to not activate

### DIFF
--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",

--- a/ext/options/options.js
+++ b/ext/options/options.js
@@ -100,14 +100,13 @@ const supportedCounts = document.getElementsByClassName('supportedCount');
   if (!sessions || sessions.length < 1) {
     workspaceSelector.classList.add('active');
     signInButton.classList.add('active');
-    return;
   }
 
-  if (sessions.length < 2) return;
-
-  workspaceSelector.addEventListener('click', () => {
-    workspaceSelector.classList.toggle('open');
-  });
+  if (sessions.length > 1) {
+    workspaceSelector.addEventListener('click', () => {
+      workspaceSelector.classList.toggle('open');
+    });
+  }
 
   for (const s of sessions) {
     const isActive = s.active ? 'active' : '';

--- a/ext/options/options.js
+++ b/ext/options/options.js
@@ -97,11 +97,14 @@ const supportedCounts = document.getElementsByClassName('supportedCount');
   addToggleListeners();
 
   const sessions = await getSessions();
+
+  // If there are no user sessions
   if (!sessions || sessions.length < 1) {
     workspaceSelector.classList.add('active');
     signInButton.classList.add('active');
   }
 
+  // If the users is associated with multiple workspaces
   if (sessions.length > 1) {
     workspaceSelector.addEventListener('click', () => {
       workspaceSelector.classList.toggle('open');


### PR DESCRIPTION
#### What's this PR do?
Ensures that provider toggles have their callbacks associated properly.

#### Where should the reviewer start?
Small diff.

#### Any background context you want to provide?
After noticing a significant drop in new extension users syncing activity I found that I accidentally introduced a bug which exited option page setup prematurely.

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
