### PR TITLE
Improve invalid session handling; add messaging around auth and sync failure states

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -99,7 +99,10 @@ async function getSessions() {
 
   const sessions = Object.values(_sessionCache);
   if (sessions.length < 1) throw 'no authenticated sessions';
-  return sessions;
+  // Return new objects so the caller does not overwrite the _sessionCache
+  return sessions.map((s) => {
+    return { ...s };
+  });
 }
 
 // Returns a map of Range API cookie slugs and cookie values. Filters cookies
@@ -117,7 +120,7 @@ function cookieMap() {
             // Filter cookies that have previously failed to authenticate
             .filter((c) => !_invalidCookieCache[c.value])
             // Filter expired cookies
-            .filter((c) => moment(c.expirationDate) - moment() / 1000 > 0)
+            .filter((c) => moment(c.expirationDate).isBefore(moment()))
             // Convert to slug:cookie_value map
             .reduce((acc, cur) => {
               acc[cur.name.substr(3)] = cur.value;

--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -8,13 +8,15 @@ const sessionCheckInterval = 30 * 1000;
 const sessionExpiryThreshold = 30 * 60 * 1000;
 
 let _sessionCache = {};
+let _invalidCookieCache = {};
 let init = refreshSessions(true);
 
 setInterval(refreshSessions, sessionCheckInterval);
+
 chrome.cookies.onChanged.addListener(async () => {
-  console.log(`refreshing sessions, cookies changed`);
+  console.log('refreshing sessions, cookies changed');
   console.log(_sessionCache);
-  await refreshSessions();
+  await refreshSessions(true);
   console.log(_sessionCache);
 });
 
@@ -30,14 +32,16 @@ async function refreshSessions(force) {
   if (force) _sessionCache = {};
 
   // Check for new Range workspace cookies
-  const cookieSlugs = await orgsFromCookies();
-  for (const s of cookieSlugs) {
-    if (!_sessionCache[s]) _sessionCache[s] = { from_cookie: true };
+  const map = await cookieMap();
+  for (const [slug, value] of Object.entries(map)) {
+    if (!_sessionCache[slug]) _sessionCache[slug] = {};
+    const session = _sessionCache[slug];
+    session.cookie_value = value;
   }
 
   for (const slug in _sessionCache) {
     // Check for removed Range workspace cookies
-    if (!cookieSlugs.includes(slug)) {
+    if (!map[slug]) {
       delete _sessionCache[slug];
       continue;
     }
@@ -45,19 +49,48 @@ async function refreshSessions(force) {
     const session = _sessionCache[slug];
     // If session newly initialized or close to expiring, refresh session
     if (
-      session.from_cookie ||
+      !session.session_expires_at ||
       moment(session.session_expires_at) - moment() < sessionExpiryThreshold
     ) {
+      const cookieValue = session.cookie_value;
       delete _sessionCache[slug];
       try {
         const newSession = await rangeLogin(slug);
         reportFirstAction(USER_ACTIONS.FIRST_LOGIN, newSession);
-        if (newSession) _sessionCache[slug] = newSession;
+        if (newSession) {
+          newSession.cookie_value = cookieValue;
+          _sessionCache[slug] = newSession;
+        } else {
+          _invalidCookieCache[cookieValue] = slug;
+        }
       } catch (_) {
         console.log(`user is not authenticated with ${slug}`);
       }
     }
   }
+
+  chrome.storage.local.get(['active_org'], (resp) => {
+    const activeOrg = resp.active_org;
+    const slugs = Object.keys(_sessionCache);
+    if (slugs.length < 1) {
+      // If there are no sessions
+      chrome.storage.local.set({ auth_state: AUTH_STATES.NO_AUTH.value });
+      chrome.browserAction.setBadgeText({ text: AUTH_STATES.NO_AUTH.badge });
+    } else if (slugs.length > 1 && !!activeOrg && !slugs.includes(activeOrg)) {
+      // If the currently selected sync session isn't authenticated
+      chrome.storage.local.set({ auth_state: AUTH_STATES.NO_SYNC_AUTH.value });
+      chrome.browserAction.setBadgeText({ text: AUTH_STATES.NO_SYNC_AUTH.badge });
+    } else if (slugs.length > 1 && !activeOrg) {
+      // If there are multiple sessions and one isn't selected for sync
+      chrome.storage.local.set({ auth_state: AUTH_STATES.NO_SYNC_SELECTED.value });
+      chrome.browserAction.setBadgeText({ text: AUTH_STATES.NO_SYNC_SELECTED.badge });
+    } else {
+      // If everything is okay
+      chrome.storage.local.set({ auth_state: AUTH_STATES.OK.value });
+      chrome.browserAction.setBadgeText({ text: AUTH_STATES.OK.badge });
+    }
+  });
+
   return;
 }
 
@@ -69,12 +102,29 @@ async function getSessions() {
   return sessions;
 }
 
-// Returns a list of authenticated org slugs from Range cookies
-function orgsFromCookies() {
+// Returns a map of Range API cookie slugs and cookie values. Filters cookies
+// that have been found to be invalid or expired
+function cookieMap() {
   return new Promise((resolve, reject) => {
     chrome.cookies.getAll({ domain: CONFIG.cookie_host || CONFIG.api_host }, (cookies) => {
-      if (cookies === null) reject(chrome.runtime.lastError.message);
-      else resolve(cookies.filter((c) => c.name.startsWith('at-')).map((c) => c.name.substr(3)));
+      if (cookies === null) {
+        reject(chrome.runtime.lastError.message);
+      } else {
+        resolve(
+          cookies
+            // Get only Range API cookies
+            .filter((c) => c.name.startsWith('at-'))
+            // Filter cookies that have previously failed to authenticate
+            .filter((c) => !_invalidCookieCache[c.value])
+            // Filter expired cookies
+            .filter((c) => moment(c.expirationDate) - moment() / 1000 > 0)
+            // Convert to slug:cookie_value map
+            .reduce((acc, cur) => {
+              acc[cur.name.substr(3)] = cur.value;
+              return acc;
+            }, {})
+        );
+      }
     });
   });
 }
@@ -159,8 +209,10 @@ function get(path, params = {}) {
 
 // Makes a request to the Range API server, handling authentication and common error cases
 async function request(path, params = {}) {
+  const isLogin = path.includes('login');
+
   // Make sure we don't do requests before we are authenticated
-  if (!path.includes('login')) await init;
+  if (!isLogin) await init;
 
   let resp;
   try {
@@ -182,7 +234,7 @@ async function request(path, params = {}) {
   if (resp.ok) return resp.json();
 
   if (resp.status === 401) {
-    if (path.includes('login')) {
+    if (isLogin) {
       console.log('failed login attempt, likely invalid cookies...');
     } else {
       console.log('no longer authenticated, refreshing sessions...');

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -140,20 +140,20 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
     case MESSAGE_TYPES.SESSIONS:
       getSessions()
         .then(async (sessions) => {
-          let resp = sessions;
-          if (sessions.length > 1) {
-            try {
-              const c = await currentSession();
-              resp = sessions
-                .filter((s) => s)
-                .map((s) => {
-                  return { ...s, active: s.org.slug == c.org.slug };
-                });
-            } catch (err) {
-              console.log(err);
-            }
+          try {
+            const c = await currentSession();
+            sessions
+              .filter((s) => s)
+              .forEach((s) => {
+                s.active = s.org.slug == c.org.slug;
+              });
+          } catch (err) {
+            // If there is an error assigning an active session, we still return
+            // the sessions after logging
+            console.log(err);
+          } finally {
+            sendResponse(sessions);
           }
-          sendResponse(resp);
         })
         .catch(handleErr);
       break;

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -51,7 +51,7 @@ chrome.tabs.onUpdated.addListener(async (_tabId, _info, tab) => {
 
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   const handleErr = (err) => {
-    console.error(err);
+    console.log(err);
     sendResponse(false);
   };
 
@@ -140,18 +140,27 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
     case MESSAGE_TYPES.SESSIONS:
       getSessions()
         .then(async (sessions) => {
-          const c = await currentSession();
-          sessions.forEach((s) => {
-            if (s) s.active = s.org.slug == c.org.slug;
-          });
-          sendResponse(sessions);
+          let resp = sessions;
+          if (sessions.length > 1) {
+            try {
+              const c = await currentSession();
+              resp = sessions
+                .filter((s) => s)
+                .map((s) => {
+                  return { ...s, active: s.org.slug == c.org.slug };
+                });
+            } catch (err) {
+              console.log(err);
+            }
+          }
+          sendResponse(resp);
         })
         .catch(handleErr);
       break;
     case MESSAGE_TYPES.SET_SESSION:
       getSessions()
         .then(async (sessions) => {
-          const s = sessions.filter((s) => s.org.slug == request.org_slug)[0];
+          const s = sessions.find((s) => s.org.slug == request.org_slug);
           sendResponse(await setActiveOrg(s.org.slug));
         })
         .catch(handleErr);
@@ -408,8 +417,8 @@ async function providerInfo(url, title, force) {
   if (!force) return null;
   // If there's no known provider, generate one based on the URL
   const hostParts = url.hostname.split('.');
-  const tld = hostParts[hostParts.length - 1];
-  const domain = hostParts[hostParts.length - 2];
+  const tld = hostParts[hostParts.length - 1] || '';
+  const domain = hostParts[hostParts.length - 2] || '';
   return {
     name: title,
     // i.e. 'subdomain.nytimes.com' -> 'chromeext_nytimes'
@@ -442,17 +451,18 @@ function blocked(blockList, url, title) {
 
 async function currentSession() {
   const sessions = await getSessions();
-  if (!sessions || sessions.length < 1) {
-    throw 'no authenticated sessions';
-  }
+  if (!sessions || sessions.length < 1) throw 'no authenticated sessions';
+  if (sessions.length == 1) return sessions[0];
 
-  return new Promise(async (resolve) => {
+  return new Promise((resolve, reject) => {
     chrome.storage.local.get(['active_org'], (resp) => {
-      const slug = resp.active_org || sessions[0].org.slug;
-      const session = sessions.find((s) => s.org.slug == slug) || sessions[0];
-      setActiveOrg(session.org.slug).then(() => {
-        resolve(session);
-      });
+      const slug = resp.active_org;
+      if (!slug) reject('no active org slug found');
+
+      const session = sessions.find((s) => s.org.slug == slug);
+      if (!session) reject(`no org found matching slug "${slug}"`);
+
+      resolve(session);
     });
   });
 }

--- a/ext/background/const.js
+++ b/ext/background/const.js
@@ -50,3 +50,14 @@ var USER_ACTIONS = {
   FIRST_INTERACTION: 'extension_first_interaction_recorded',
   FIRST_SNIPPET: 'extension_first_snippet',
 };
+
+var AUTH_STATES = {
+  // Not authenticated at all
+  NO_AUTH: { value: 'NO_AUTH', badge: 'AUTH' },
+  // Currently selected session is no longer authenticated
+  NO_SYNC_AUTH: { value: 'NO_SYNC_AUTH', badge: 'AUTH' },
+  // Multiple sessions are authenticated but none are selected
+  NO_SYNC_SELECTED: { value: 'NO_SYNC_SELECTED', badge: 'SYNC' },
+  // Everything is okay
+  OK: { value: 'OK', badge: '' },
+};

--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",

--- a/ext/options/options.css
+++ b/ext/options/options.css
@@ -86,6 +86,8 @@ hr {
 
 #workspaceOr.active {
   display: block;
+  font-weight: 300;
+  margin: 5px;
 }
 
 #workspaceButton {

--- a/ext/options/options.css
+++ b/ext/options/options.css
@@ -80,13 +80,20 @@ hr {
   display: block;
 }
 
+#workspaceOr {
+  display: none;
+}
+
+#workspaceOr.active {
+  display: block;
+}
+
 #workspaceButton {
   display: none;
 }
 
 #workspaceButton.active {
   display: block;
-  margin: 0;
   outline: none;
 }
 

--- a/ext/options/options.html
+++ b/ext/options/options.html
@@ -19,8 +19,9 @@
     </div>
     <div id="workspaceSelector">
       <a class="largeButton" id="signInButton" href="https://range.co/login" target="_blank">Sign in to Range</a>
+      <span id="workspaceOr">OR</span>
       <button class="largeButton" id="workspaceButton">
-        <span>Syncing to: </span><span class="activeOrg"></span><img id="workspaceIndicator"
+        <span>Sync to: </span><span class="activeOrg"></span><img id="workspaceIndicator"
           src="/images/accordion-indicator.png" />
       </button>
       <div id="workspaceContent">

--- a/ext/popup/popup.css
+++ b/ext/popup/popup.css
@@ -84,6 +84,13 @@ hr {
   padding: 10px 0px 10px 15px;
 }
 
+.noActiveWorkspace {
+  display: none;
+  flex-direction: column;
+  justify-content: left;
+  padding: 10px 0px 10px 15px;
+}
+
 .largeButton {
   background: #00bfd8;
   border: 0;

--- a/ext/popup/popup.html
+++ b/ext/popup/popup.html
@@ -14,11 +14,19 @@
   </div>
   <div class="unauthenticated">
     <p>
-      Welcome to Range Chrome Sync.
+      Welcome to Range Chrome Sync!
       <a href="https://chrome.google.com/webstore/detail/range-for-chrome/mbnkiifdpdcimfcdhmioinhcbjngjebo"
         target="_blank">Learn more</a>.
     </p>
     <a class="largeButton" href="https://range.co/login" target="_blank">Sign in to Range</a>
+  </div>
+  <div class="noActiveWorkspace">
+    <p>
+      Welcome to Range Chrome Sync!
+      <a href="https://chrome.google.com/webstore/detail/range-for-chrome/mbnkiifdpdcimfcdhmioinhcbjngjebo"
+        target="_blank">Learn more</a>.
+    </p>
+    <a class="largeButton settingsLink">Please sync a Range workspace</a>
   </div>
   <div class="authenticated">
     <div id="checkInStatus">


### PR DESCRIPTION
#### What's this PR do?
At the moment it is possible for a Range session to expire or become invalid while the cookie appears to be valid. This change caches invalid cookies, adds a badge to the extension icon, as well as other UI tweaks to guide a user through resolving the problem.

The states that are addressed are:
1. There are no authenticated sessions
    1. Add a "AUTH" badge
    2. Popup prompts user to sign in
    3. Options page prompts user to sign in
2. The user has multiple workspaces and hasn't selected on to sync with
    1. Add "SYNC" badge
    2. Popup prompts user to go to options page and choose a workspace to sync
    3. Options page presents the dropdown of possible workspaces
3. The user has multiple workspaces and loses authentication to the one that has been chosen for sync
    1. Add a "AUTH" badge
        1. I chose "AUTH" rather than "SYNC" because the primary reason for the issue is that their authentication is no longer valid in the workspace that they likely want to continue syncing to. So it is an auth issue at the core.
    2. Popup prompts user to sign in
    3. Options page presents the sign in button as well as the dropdown of possible workspaces

#### Where should the reviewer start?
Commit by commit.


#### Screenshots

Unauthenticated:
Popup:
![image](https://user-images.githubusercontent.com/4957087/108782764-08fb7580-7521-11eb-8d86-10515f92c27c.png)

Options:
![image](https://user-images.githubusercontent.com/4957087/108783230-f33a8000-7521-11eb-8cdb-64d604d15e32.png)

Multiple authenticated workspaces, none selected:
Popup:
![image](https://user-images.githubusercontent.com/4957087/108782827-29c3cb00-7521-11eb-9da5-a67c1573fff7.png)

Options:
![image](https://user-images.githubusercontent.com/4957087/108782860-38aa7d80-7521-11eb-99a2-43dfac339030.png)

Multiple authenticated workspaces, the one selected is unauthenticated:
Popup:
![image](https://user-images.githubusercontent.com/4957087/108782764-08fb7580-7521-11eb-8d86-10515f92c27c.png)

Options:
![image](https://user-images.githubusercontent.com/4957087/108782912-4f50d480-7521-11eb-9408-ad85ede910c5.png)
