### PR TITLE
Add recent interaction cache and fix invalid cookie tracking. Bump version to 2.4.2

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -57,13 +57,10 @@ async function refreshSessions(force) {
       try {
         const newSession = await rangeLogin(slug);
         reportFirstAction(USER_ACTIONS.FIRST_LOGIN, newSession);
-        if (newSession) {
-          newSession.cookie_value = cookieValue;
-          _sessionCache[slug] = newSession;
-        } else {
-          _invalidCookieCache[cookieValue] = slug;
-        }
+        newSession.cookie_value = cookieValue;
+        _sessionCache[slug] = newSession;
       } catch (_) {
+        _invalidCookieCache[cookieValue] = slug;
         console.log(`user is not authenticated with ${slug}`);
       }
     }
@@ -236,7 +233,7 @@ async function request(path, params = {}) {
 
   if (resp.ok) return resp.json();
 
-  if (resp.status === 401) {
+  if (resp.status === 401 || resp.status === 403) {
     if (isLogin) {
       console.log('failed login attempt, likely invalid cookies...');
     } else {

--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",


### PR DESCRIPTION
#### What's this PR do?
This PR resolves 2 issues:

Range was getting many duplicate requests to the `RecordInteraction` endpoint. This should cut down on them by creating a simple cache with the source ID and active session's org slug as a key.

Invalid cookies were not being added to the invalid cookie cache. Also, the wrong error code was being checked for when invalid authentication occurred. This was causing lots of failed Range auth requests.

#### Where should the reviewer start?
Cookie fixes are in `api.js`. Cache is in `background.js`.

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
