### PR TITLE
Revert RecordInteraction deduping. Bump version to 2.4.3

### DIFF
--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -8,11 +8,6 @@ const ATTACHMENT_CORE = ['source_id', 'provider', 'org_id', 'type', 'origin', 'n
 // These are the onInstalled reasons that will trigger the options page to open
 const _openOptionsReasons = ['install', 'update'];
 
-// 1 hour
-const dedupeThreshold = 60 * 60 * 1000;
-// This is used to reduce the number of requests to Range servers
-const _recordInteractionCache = {};
-
 chrome.runtime.onInstalled.addListener(async (d) => {
   chrome.storage.local.get(['active_providers'], (r) => {
     // Carry over active providers from previous install
@@ -293,11 +288,6 @@ async function attemptRecordInteraction(
 
   const a = await attachment(session, tab, force);
   if (!a) throw 'could not create attachment for interaction';
-  const dedupeKey = `${session.org.org_id}:${a.source_id}`;
-  const waitTime = _recordInteractionCache[dedupeKey];
-  if (!!waitTime && moment().isBefore(waitTime)) {
-    throw 'recently recorded interaction for this org and source ID';
-  }
 
   setChromeActivity(a, tab);
 
@@ -311,7 +301,6 @@ async function attemptRecordInteraction(
     },
     authorize(session)
   );
-  _recordInteractionCache[dedupeKey] = moment().add(dedupeThreshold, 'ms');
   setBackfillTime(merged.provider);
 
   return resp;

--- a/ext/background/const.js
+++ b/ext/background/const.js
@@ -14,7 +14,7 @@ const MERGE_BEHAVIOR = {
 
 // Currently inelegant, but this is a quick way of tracking what new providers
 // have been added in a given update.
-const NEW_PROVIDERS = ['monday', 'bitbucket', 'bitbucket_enterprise', 'box'];
+const NEW_PROVIDERS = [];
 
 var INTEGRATION_STATUSES = {
   ENABLED: 'ENABLED',

--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",


### PR DESCRIPTION
#### What's this PR do?
Reverts the attachment deduping introduced in 2.4.2. Users reported attachment titles that were not valid, caused by unloaded webpages persisting their titles.

#### Where should the reviewer start?
Small diff.

#### What are the relevant tickets?
#46 

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
