### PR TITLE
Fix login spam by using new max_age session field from the login RPC. Bump version to 2.4.4

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -46,8 +46,8 @@ async function refreshSessions(force) {
     // If session newly initialized or close to expiring, refresh session
     if (
       !session.session_max_age ||
-      !session.local_session_expires_atx ||
-      moment(session.local_session_expires_atx) - moment() < sessionExpiryThreshold
+      !session.local_session_expires_at ||
+      moment(session.local_session_expires_at) - moment() < sessionExpiryThreshold
     ) {
       const cookieValue = session.cookie_value;
       delete _sessionCache[slug];

--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -60,7 +60,7 @@ async function refreshSessions(force) {
         // requests if a user's computer thought that its time was after the session expiration
         // time.
         newSession.local_session_expires_at = moment()
-          .add(session.session_max_age, 'milliseconds')
+          .add(session.session_max_age, 'seconds')
           .toISOString();
         _sessionCache[slug] = newSession;
       } catch (_) {
@@ -237,11 +237,13 @@ async function request(path, params = {}) {
 
   if (resp.ok) return resp.json();
 
-  if (isLogin) {
-    console.log('failed login attempt, likely invalid cookies');
-  } else if (resp.status === 401 || resp.status === 403) {
-    console.log('no longer authenticated, refreshing sessions');
-    await refreshSessions(true);
+  if (resp.status === 401 || resp.status === 403) {
+    if (isLogin) {
+      console.log('failed login attempt, likely invalid cookies...');
+    } else {
+      console.log('no longer authenticated, refreshing sessions...');
+      await refreshSessions(true);
+    }
   } else {
     console.log(`invalid request: (${resp.status}, ${resp.statusText})`);
   }

--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",
@@ -29,6 +29,7 @@
       "background/filter/metabase.js",
       "background/filter/monday.js",
       "background/filter/notion.js",
+      "background/filter/onedrive.js",
       "background/filter/quip.js",
       "background/filter/stack_overflow.js"
     ],

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",
@@ -29,6 +29,7 @@
       "background/filter/metabase.js",
       "background/filter/monday.js",
       "background/filter/notion.js",
+      "background/filter/onedrive.js",
       "background/filter/quip.js",
       "background/filter/stack_overflow.js"
     ],


### PR DESCRIPTION
#### What's this PR do?
Calculates the action session refresh time using the `max_age` session field.

#### Where should the reviewer start?
Small diff.

#### Any background context you want to provide?
Range is still being spammed by login requests. This was caused by user's clocks being out of sync with the timestamps used in the `session_expires_at` field. To combat this we calculate a `local_session_expires_at` using the new `max_age` milliseconds from the request.

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
