### PR TITLE
Fix recording interactions with the proper type

### DIFF
--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -297,7 +297,7 @@ async function attemptRecordInteraction(
   const merged = await mergeAttachment(session, a);
   const resp = await recordInteraction(
     {
-      interaction_type: (_) => 'VIEWED',
+      interaction_type: 'VIEWED',
       idempotency_key: `${moment().startOf('day')}::${tab.title}`,
       interaction_at: interactionAt,
       attachment: merged,

--- a/ext/manifest.dev.json
+++ b/ext/manifest.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "[DEV] Range Sync for Chrome",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "[DEV] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habdev.site/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.range.co/*"],
   "options_page": "options/options.html",

--- a/ext/manifest.staging.json
+++ b/ext/manifest.staging.json
@@ -1,6 +1,6 @@
 {
   "name": "[STAGING] Range Sync for Chrome",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "[STAGING] Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs", "https://*.habitat.team/*"],
   "options_page": "options/options.html",


### PR DESCRIPTION
#### What's this PR do?

It looks like, since version 2.0.0, we had a typo that meant that the `interaction_type` field was not being properly sent to our endpoint when recording interactions from the Chrome extension. We want to use the type `VIEWED`, but instead we were getting `UNSET`.

This change fixes the typo by removing the lambda function that seems like it was just accidentally added.

Following the code path, this is passed through `recordInteraction` in api.js to `post` and then directly into `JSON.stringify`. According to [the docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), the function value for `interaction_type` would just be omitted in that case, so it seems that this has never been working as we intended.

> undefined, Functions, and Symbols are not valid JSON values. If any such values are encountered during conversion they are either omitted (when found in an object) or changed to null (when found in an array).

#### Where should the reviewer start?

One line diff!

#### What gif best describes this PR or how it makes you feel?

![found the problem](https://c.tenor.com/u4FZTtqXiuwAAAAd/i-think-i-found-the-problem-stevie-budd.gif)

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
