### PR TITLE
Add query parameters to source id for unknown urls

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -245,15 +245,3 @@ async function request(path, params = {}) {
   }
   throw await resp.json();
 }
-
-// Implementation of Java's String.hashCode. Not secure.
-function hashCode(str) {
-  let hash = 0;
-  if (!str || str.length === 0) return hash;
-  for (let i = 0; i < str.length; i++) {
-    let char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash;
-  }
-  return hash;
-}

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -430,6 +430,16 @@ async function providerInfo(url, title, force) {
 
   // No filter found for any domain; return null to avoid spam
   if (!force) return null;
+
+  let search = '';
+  if (url.search) {
+    // URL with search params in a different order should result in the same
+    // destination.
+    const searchParams = new URLSearchParams(url.search)
+    searchParams.sort();
+    search = '?' + searchParams.toString();
+  }
+
   // If there's no known provider, generate one based on the URL
   const hostParts = url.hostname.split('.');
   const tld = hostParts[hostParts.length - 1] || '';
@@ -442,7 +452,7 @@ async function providerInfo(url, title, force) {
     provider_name: `${domain}.${tld} (via Range Sync)`,
     // prefixing 'chromeext_' will make it easier to find out what providers
     // to add next
-    source_id: `chromeext_${base}`,
+    source_id: `chromeext_${base + search}`,
     type: DEFAULT_TYPE,
     subtype: DEFAULT_SUBTYPE,
   };

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -439,7 +439,7 @@ async function providerInfo(url, title, force) {
     searchParams.sort();
     const hashBytes = toBytesInt32(hashCode(searchParams.toString()));
     const base64 = btoa(String.fromCharCode(...hashBytes));
-    search = '_' + base64.replace(/=+$/g, '');
+    search = '_' + base64.replace(/=+$/g, '').replace(/\+/g, '-').replace(/\//g, '_');
   }
 
   // If there's no known provider, generate one based on the URL

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -437,13 +437,9 @@ async function providerInfo(url, title, force) {
     // destination.
     const searchParams = new URLSearchParams(url.search)
     searchParams.sort();
-    const hash = hashCode(searchParams.toString());
-    // Drops the sign bit so we can arrive at an alphanumeric string without
-    // a "-" prefix.
-    //
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift#description
-    const postiveHash = hash >>> 0;
-    search = '_' + postiveHash.toString(36);
+    const hashBytes = toBytesInt32(hashCode(searchParams.toString()));
+    const base64 = btoa(String.fromCharCode(...hashBytes));
+    search = '_' + base64.replace(/=+$/g, '');
   }
 
   // If there's no known provider, generate one based on the URL
@@ -563,4 +559,13 @@ function hashCode(str) {
     hash = hash & hash;
   }
   return hash;
+}
+
+function toBytesInt32(num) {
+  return new Uint8Array([
+    (num & 0xff000000) >> 24,
+    (num & 0x00ff0000) >> 16,
+    (num & 0x0000ff00) >> 8,
+    (num & 0x000000ff)
+  ]);
 }

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -437,7 +437,13 @@ async function providerInfo(url, title, force) {
     // destination.
     const searchParams = new URLSearchParams(url.search)
     searchParams.sort();
-    search = '?' + searchParams.toString();
+    const hash = hashCode(searchParams.toString());
+    // Drops the sign bit so we can arrive at an alphanumeric string without
+    // a "-" prefix.
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift#description
+    const postiveHash = hash >>> 0;
+    search = '_' + postiveHash.toString(36);
   }
 
   // If there's no known provider, generate one based on the URL

--- a/ext/background/background.js
+++ b/ext/background/background.js
@@ -546,3 +546,15 @@ function setBackfillTime(provider) {
     });
   });
 }
+
+// Implementation of Java's String.hashCode. Not secure.
+function hashCode(str) {
+  let hash = 0;
+  if (!str || str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    let char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return hash;
+}


### PR DESCRIPTION
#### What's this PR do?

Adds query parameters to pages that don't have valid filters.

#### Where should the reviewer start?

#### Any background context you want to provide?

A popular example of the type of failure this fixes is Youtube. Instead of all Youtube videos being reduced to `chromeext_www.youtube.com/watch`, they'll now have unique source ids per video `chromeext_www.youtube.com/watch?v=-92JS2FbiHk`.

A risk will be having multiple attachments for the same page, for example Youtube videos also having a start timestamp in the url. But this risk seems tolerable compared to not being able to include unique pages on sites relying on url search parameters.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
