### PR TITLE
Fix Confluence integration's sourceId creation

### DIFF
--- a/ext/background/filter/confluence.js
+++ b/ext/background/filter/confluence.js
@@ -12,12 +12,19 @@ registerFilter({
         const parts = url.pathname.split('/');
         if (parts.length != 7) return null;
 
+        const projectId = parts[3];
+        let documentId;
+
         const reEdit = /\/edit(?:-v2)?\//;
         if (reEdit.test(url)) {
-          return `${parts[2]}-${parts[5]}`;
+          // "/wiki/spaces/RR/pages/edit-v2/12345"
+          documentId = parts[6];
         } else {
-          return `${parts[2]}-${parts[4]}`;
+          // "/wiki/spaces/RR/pages/12345/My+first+confluence+document"
+          documentId = parts[5];
         }
+
+        return `${projectId}-${documentId}`;
       },
       // i.e. 'Edit - Here's a neat document - Range Labs - Confluence' -> 'Here's a neat document'
       // i.e. 'Here's a neat document - Range Labs - Confluence' -> 'Here's a neat document'

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range Sync for Chrome",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Capture work from your browser based tools and share progress with your team",
   "permissions": ["cookies", "history", "storage", "tabs"],
   "host_permissions": ["https://*.range.co/*"],


### PR DESCRIPTION
#### What's this PR do?

Fixes issue where all confluence docs share the same non-unique source id, resulting in the following unexpected scenario:

1. Add Confluence activity to Check-in.
2. Visit new Confluence document.
3. Activity in Check-in changes to the url of the latest visited page.

#### Where should the reviewer start?

#### Any background context you want to provide?

I tested this successfully locally.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
