### PR TITLE
Improve handling of Jira titles with customized site name

### DIFF
--- a/ext/background/filter/jira.js
+++ b/ext/background/filter/jira.js
@@ -18,9 +18,12 @@
           return `${hostname}/${issueKey}`;
         },
         title_processor: (title) => {
-          if (title.endsWith(' - Jira')) {
+          // Jira document titles end with a dash and the name of the Jira instance, like "- Jira".
+          // However, this name is customizable. We just remove whatever comes after the last dash.
+          if (title.includes(' - ')) {
             title = trimLastPart(title, ' - ');
           }
+
           if (title.startsWith('[')) {
             // The leading issue key will be included in the issue_info.
             // Remove the leading leading "[AB-1] ".


### PR DESCRIPTION
#### What's this PR do?

A customer reported that they're not able to add some Jira items. It turns out the root cause is a mismatched attachment name, which is being caused by us not stripping a customized Jira site name off the end of the document title.

#### Where should the reviewer start?

Small diff

#### Any background context you want to provide?

I haven't tested this, but I think it should be pretty safe based on log analysis and the customer's reports.

#### What gif best describes this PR or how it makes you feel?

![name change](https://c.tenor.com/eH9wRlmpOOMAAAAC/can-you-change-your-name-leon.gif)

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
